### PR TITLE
Remove the need to change username in index.coffee

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,11 +1,3 @@
-Installation:
-
-1. Move solar-system.widget to your widgets folder
-2. Open index.coffee (TextEdit will work)
-3. On the second line, make sure to change "USER" to your username/homefolder
-4. Save and close
-5. Enjoy!
-
 Customization:
 
 1. Open index.coffee (TextEdit will work)

--- a/index.coffee
+++ b/index.coffee
@@ -1,5 +1,4 @@
-#CHANGE "USER" TO YOUR USERNAME/HOMEFOLDER!!!
-command: "cd '/Users/USER/Library/Application\ Support/Übersicht/widgets/solar-system.widget/' && ./script.sh"
+command: "cd ~/Library/Application\\ Support/Übersicht/widgets/solar-system.widget/ && ./script.sh"
 
 #Sets refresh rate in milliseconds
 #Default = 86400000 (1 day)


### PR DESCRIPTION
The `~` character can be used to denote the current user's home directory in Unix. This removes the need for users to change that line in `index.coffee` upon installation. This pull request makes that code change and removes the relevant installation doc in `README.txt`.

Thank you for the widget!